### PR TITLE
prevent empty tags

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 cd /Volumes/workspace/repository/
 pwd
+git fetch --unshallow
 git fetch --tags
-NEW_VERSION=$(git describe --abbrev=0)
+NEW_VERSION=$(git describe --abbrev=0 --tags --always)
 echo "Setting marketing version to $NEW_VERSION"
 sed -i "" -e "s/\(MARKETING_VERSION = \)[^;]*/\1$NEW_VERSION/" /Volumes/workspace/repository/Tiqr\ Client.xcodeproj/project.pbxproj
 


### PR DESCRIPTION
If not the complete git history is downloaded, the git describe commando might return an empty string, causing a build error.