### PR TITLE
TIQR-455: Request notification token even if we don't have permission

### DIFF
--- a/Tiqr/AppDelegate.swift
+++ b/Tiqr/AppDelegate.swift
@@ -42,13 +42,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error = error {
                 print(error.localizedDescription)
-            } else if granted {
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
             }
         }
-
+        UIApplication.shared.registerForRemoteNotifications()
         if #available(iOS 13, *) { } else {
             self.window = UIWindow(frame: UIScreen.main.bounds)
             self.window?.rootViewController = Tiqr.shared.startWithOptions(options: launchOptions, theme: Theme())

--- a/Tiqr/Info.plist
+++ b/Tiqr/Info.plist
@@ -2,24 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>TIQRTokenExchangeURL</key>
-	<string>https://tx.tiqr.org/tokenexchange/?appId=</string>
-	<key>TIQRTokenExchangeEnabled</key>
-	<true/>
-	<key>TIQREnforceChallengeHosts</key>
-	<string>$(TIQR_ENFORCE_CHALLENGE_HOSTS)</string>
-	<key>TIQREnrollmentURLPathParameter</key>
-	<string>$(TIQR_ENROLLMENT_URL_PATH_PARAMETER)</string>
-	<key>TIQRAuthenticationURLPathParameter</key>
-	<string>$(TIQR_AUTHENTICATION_URL_PATH_PARAMETER)</string>
-	<key>TIQREnrollmentURLScheme</key>
-	<string>$(TIQR_ENROLLMENT_URL_SCHEME)</string>
-	<key>TIQRAuthenticationURLScheme</key>
-	<string>$(TIQR_AUTHENTICATION_URL_SCHEME)</string>
-	<key>TIQRGitReleaseVersion</key>
-	<string>?</string>
-	<key>TIQRLibraryVersion</key>
-	<string>?</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -60,6 +42,24 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>TIQRAuthenticationURLPathParameter</key>
+	<string>$(TIQR_AUTHENTICATION_URL_PATH_PARAMETER)</string>
+	<key>TIQRAuthenticationURLScheme</key>
+	<string>$(TIQR_AUTHENTICATION_URL_SCHEME)</string>
+	<key>TIQREnforceChallengeHosts</key>
+	<string>$(TIQR_ENFORCE_CHALLENGE_HOSTS)</string>
+	<key>TIQREnrollmentURLPathParameter</key>
+	<string>$(TIQR_ENROLLMENT_URL_PATH_PARAMETER)</string>
+	<key>TIQREnrollmentURLScheme</key>
+	<string>$(TIQR_ENROLLMENT_URL_SCHEME)</string>
+	<key>TIQRGitReleaseVersion</key>
+	<string>?</string>
+	<key>TIQRLibraryVersion</key>
+	<string>?</string>
+	<key>TIQRTokenExchangeEnabled</key>
+	<true/>
+	<key>TIQRTokenExchangeURL</key>
+	<string>https://tx.tiqr.org/tokenexchange/?appId=</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -77,5 +77,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Before we just got a token when the user has given us access.
This way we already have a token, and we can send pushes immediately after the user approves it for the app.